### PR TITLE
Infra 1381 puppet artifactory

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'jcraigbrown-artifactory'
-version '0.0.4'
+version '0.0.5'
 source 'https://github.com/jcraigbrown/artifactory.git'
 author 'J. Craig Brown'
 license 'Apache License, Version 2.0'

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -12,6 +12,7 @@
 # [*repository*] : The repository such as 'public', 'central'... (defaults to
 # 'releases' or 'snapshots' depending on the version specified in gav
 # [*output*] : The output file (defaults to the resource name)
+# [*s3_bucket*] : if specified, will retrieve files via aws s3 api. if not specified, https is assumed with the Artifactory base url
 #
 # Actions:
 # If repository is set, its setting will be honoured.
@@ -87,7 +88,13 @@ define artifactory::artifact(
     $timestampedRepo = ''
   }
 
-  $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::artifactory_url} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
+  if ($artifactory::s3 == true) {
+    $s3 = "-s"
+  } else {
+    $s3 = ''
+  }
+
+  $cmd = "/opt/artifactory-script/download-artifact-from-artifactory.sh $s3 -a ${gav} -e ${packaging} ${includeClass} -n ${artifactory::artifactory_url} ${includeRepo} ${timestampedRepo} -o ${output} ${args} -v"
 
   if $ensure == present {
     exec { "Download ${gav}-${classifier} to ${output}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,8 +21,7 @@ class artifactory(
   $url = '',
   $username = '',
   $password = '',
-  $s3 = false)
-  {
+  $s3 = false) {
 
   # Check arguments
   # url mandatory

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,28 +20,34 @@
 class artifactory(
   $url = '',
   $username = '',
-  $password = '')
-{
+  $password = '',
+  $s3 = false)
+  {
 
-  # Check arguments
-  # url mandatory
-  if $url == '' {
-    fail('Cannot initialize the Artifactory class - the url parameter is mandatory')
+    # Check arguments
+    # url mandatory
+    if $url == '' {
+      fail('Cannot initialize the Artifactory class - the url parameter is mandatory')
+    }
+    $artifactory_url = $url
+
+
+    if $s3 == false {
+      #rely on iam authentication
+      $authentication = false
+    } else {
+      if ($username != '') and ($password == '') {
+        fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
+      } elsif ($username == '') and ($password != '') {
+        fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
+      } elsif ($username == '') and ($password == '') {
+        $authentication = false
+      } else {
+        $authentication = true
+        $user = $username
+        $pwd = $password
+      }
   }
-  $artifactory_url = $url
-
-  if ($username != '') and ($password == '') {
-    fail('Cannot initialize the Artifactory class - both username and password must be set')
-  } elsif ($username == '') and ($password != '') {
-    fail('Cannot initialize the Artifactory class - both username and password must be set')
-  } elsif ($username == '') and ($password == '') {
-    $authentication = false
-  } else {
-    $authentication = true
-    $user = $username
-    $pwd = $password
-  }
-
   # Install script
   file { '/opt/artifactory-script/download-artifact-from-artifactory.sh':
     ensure   => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,29 +24,29 @@ class artifactory(
   $s3 = false)
   {
 
-    # Check arguments
-    # url mandatory
-    if $url == '' {
-      fail('Cannot initialize the Artifactory class - the url parameter is mandatory')
-    }
-    $artifactory_url = $url
+  # Check arguments
+  # url mandatory
+  if $url == '' {
+    fail('Cannot initialize the Artifactory class - the url parameter is mandatory')
+  }
 
+  $artifactory_url = $url
 
-    if $s3 == false {
-      #rely on iam authentication
+  if $s3 == true {
+    #rely on iam authentication
+    $authentication = false
+  } else {
+    if ($username != '') and ($password == '') {
+      fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
+    } elsif ($username == '') and ($password != '') {
+      fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
+    } elsif ($username == '') and ($password == '') {
       $authentication = false
     } else {
-      if ($username != '') and ($password == '') {
-        fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
-      } elsif ($username == '') and ($password != '') {
-        fail('Cannot initialize the Artifactory class - both username and password must be set if not using s3')
-      } elsif ($username == '') and ($password == '') {
-        $authentication = false
-      } else {
-        $authentication = true
-        $user = $username
-        $pwd = $password
-      }
+      $authentication = true
+      $user = $username
+      $pwd = $password
+    }
   }
   # Install script
   file { '/opt/artifactory-script/download-artifact-from-artifactory.sh':


### PR DESCRIPTION
**Purpose**: enable this puppet module to pull artifacts from an s3 bucket (in addition to an Artifactory server, it's current capability)

**How:** : if the `s3` property passed in is set to true, it will pull from s3 via the aws cli. Appropriate IAM permissions for the node must permit access to the artifactory directory in the s3 repository. The Artifactory URL passed in must be the s3 URI to the bucket, ie s3://artifactory-bucket. If s3 is false, it will act the same as it does today, which is to curl the given Artifactory server url.

**Validation**: Created a test s3 bucket and copied over artifacts from our qa Artifactory server. Launched tapp-monkey and tapp-tokenization roles with a dsc feature branch pointing to this feature branch and ran papply on them to confirm that the appropriate artifacts were successfully downloaded from the s3 bucket repo, and confirmed the services started successfully. 

This will go along with several other PRs that combine to enable the s3 artifactory support. OK to merge before any of those, since it will still work with our current Artifactory server.

I wasn't sure if it was necessary, but i bumped the version in the Modulefile.

Config in dsc will look like this:
artifactory::url: "s3://artifactory-bucket-name"
artifactory::s3: true